### PR TITLE
Remove ctrl from close window

### DIFF
--- a/sxhkd/sxhkdrc
+++ b/sxhkd/sxhkdrc
@@ -65,7 +65,7 @@ super + shift + {e,r}
 	bspc {quit,wm -r}
 
 # close and kill
-{super,ctrl} + {_,shift + }w
+super + {_,shift + }w
 	bspc node -{c,k}
 
 # alternate between the tiled and monocle layout


### PR DESCRIPTION
Remove ctrl form close window because I don't want to close windows
instead of closing browser tabs.